### PR TITLE
Add timeout and error handling to getStdIn method

### DIFF
--- a/demo/Commands/DemoOptionsStrictTypes.php
+++ b/demo/Commands/DemoOptionsStrictTypes.php
@@ -179,7 +179,7 @@ class DemoOptionsStrictTypes extends CliCommand
 
         // //////////////////////////////////////// Standard input
         // echo " Qwerty 123 " | php ./my-app examples:agruments
-        self::getStdIn(); // " Qwerty 123 \n"
+        $this->_('STDIN: "' . self::getStdIn() . '"'); // " Qwerty 123 \n"
 
         // Default success exist code is "0". Max value is 255.
         return self::SUCCESS;


### PR DESCRIPTION
The getStdIn method in `CliCommand.php` now accepts a timeout parameter and includes error handling mechanisms for reading from `STDIN`. It implements a timeout during read operations and throws exceptions if the read operation fails or is timed out, enhancing robustness and failure mode handling.

Related issue https://github.com/JBZoo/CI-Report-Converter/issues/43