### PR TITLE
Fixed profiler formatting

### DIFF
--- a/demo/Commands/DemoOutput.php
+++ b/demo/Commands/DemoOutput.php
@@ -57,7 +57,7 @@ class DemoOutput extends CliCommand
 
         // `cli($text)` is global alias for `$this->_();`
 
-        // \sleep(1);
+        \usleep(25000);
 
         // Info output
         // ./my-app examples:output -v

--- a/demo/Commands/DemoOutput.php
+++ b/demo/Commands/DemoOutput.php
@@ -58,6 +58,8 @@ class DemoOutput extends CliCommand
         // `cli($text)` is global alias for `$this->_();`
 
         \usleep(25000);
+        // \sleep(5);
+        $range = \range(1, 1000000);
 
         // Info output
         // ./my-app examples:output -v
@@ -74,6 +76,8 @@ class DemoOutput extends CliCommand
         if ($this->isWarningLevel()) {
             cli();
         }
+
+        unset($range);
 
         // Debug output
         // ./my-app examples:output -vvv

--- a/src/OutputMods/Text.php
+++ b/src/OutputMods/Text.php
@@ -236,14 +236,20 @@ class Text extends AbstractOutputMode
             if ($this->isDisplayProfiling()) {
                 $profile = $this->getProfileInfo();
 
-                $timeDiff = \number_format($profile['time_diff_ms'] / 1000, 2);
-                $timeDiff = $timeDiff === '0.00' ? "<gray>{$timeDiff}s</gray>" : "{$timeDiff}s";
-
                 $timeTotal = \number_format($profile['time_total_ms'] / 1000, 2);
+
+                $timeDiff = \number_format($profile['time_diff_ms'] / 1000, 2);
+                $timeDiff = $timeDiff === '0.00' ? '<gray>    -</gray>' : "{$timeDiff}s";
 
                 $memoryDiff = FS::format($profile['memory_usage_diff'], 0);
                 $memoryDiff = \str_pad($memoryDiff, 6, ' ', \STR_PAD_LEFT);
-                $memoryDiff = $profile['memory_usage_diff'] === 0 ? "<gray>{$memoryDiff}</gray>" : $memoryDiff;
+                if ($profile['memory_usage_diff'] === 0) {
+                    $memoryDiff = '<gray>' . \str_pad('0', 6, ' ', \STR_PAD_LEFT) . '</gray>';
+                } else {
+                    $memoryDiff = $profile['memory_usage_diff'] > 0
+                        ? "<yellow>{$memoryDiff}</yellow>"
+                        : "<green>{$memoryDiff}</green>";
+                }
 
                 $profilerData = [];
                 if ($this instanceof Cron) {
@@ -255,7 +261,7 @@ class Text extends AbstractOutputMode
                         $profilerData[] = $timeDiff;
                         $profilerData[] = $memoryDiff;
                         $profilerData[] = FS::format($profile['memory_usage'], 0);
-                        $profilerData[] = 'Peak: ' . FS::format($profile['memory_peak'], 0);
+                        $profilerData[] = 'P: ' . FS::format($profile['memory_peak'], 0);
                     } elseif ($this->showMessage(OutputInterface::VERBOSITY_VERY_VERBOSE)) {
                         $profilerData[] = $timeTotal;
                         $profilerData[] = $timeDiff;
@@ -272,7 +278,7 @@ class Text extends AbstractOutputMode
                 }
 
                 $profilePrefix .= '<green>[</green>'
-                    . \implode(' <green>/</green> ', $profilerData)
+                    . \implode(' <green>|</green> ', $profilerData)
                     . '<green>]</green> ';
             }
             $printCallback($profilePrefix);

--- a/src/OutputMods/Text.php
+++ b/src/OutputMods/Text.php
@@ -235,6 +235,7 @@ class Text extends AbstractOutputMode
         if ($executePrint && $printCallback !== null) {
             if ($this->isDisplayProfiling()) {
                 $profile = $this->getProfileInfo();
+                $oneKb   = 1024;
 
                 $timeTotal = \str_pad(\number_format($profile['time_total_ms'] / 1000, 2), 5, ' ', \STR_PAD_LEFT);
 
@@ -243,7 +244,7 @@ class Text extends AbstractOutputMode
 
                 $memoryDiff = FS::format($profile['memory_usage_diff'], 0);
                 $memoryDiff = \str_pad($memoryDiff, 6, ' ', \STR_PAD_LEFT);
-                if (\abs($profile['memory_usage_diff']) < 1024) {
+                if (\abs($profile['memory_usage_diff']) < $oneKb) {
                     $memoryDiff = '<gray>' . \str_pad($memoryDiff, 6, ' ', \STR_PAD_LEFT) . '</gray>';
                 } else {
                     $memoryDiff = $profile['memory_usage_diff'] > 0

--- a/src/OutputMods/Text.php
+++ b/src/OutputMods/Text.php
@@ -73,7 +73,7 @@ class Text extends AbstractOutputMode
             $outputLevel,
         );
 
-        $this->_("Exit Code is \"{$exitCode}\"", $outputLevel);
+        $this->_("Exit Code is \"{$exitCode}\"", OutLvl::DEBUG);
     }
 
     public function onExecException(\Exception $exception): void
@@ -236,15 +236,15 @@ class Text extends AbstractOutputMode
             if ($this->isDisplayProfiling()) {
                 $profile = $this->getProfileInfo();
 
-                $timeTotal = \number_format($profile['time_total_ms'] / 1000, 2);
+                $timeTotal = \str_pad(\number_format($profile['time_total_ms'] / 1000, 2), 5, ' ', \STR_PAD_LEFT);
 
-                $timeDiff = \number_format($profile['time_diff_ms'] / 1000, 2);
-                $timeDiff = $timeDiff === '0.00' ? '<gray>    -</gray>' : "{$timeDiff}s";
+                $timeDiff = \str_pad(\number_format($profile['time_diff_ms'] / 1000, 2), 5, ' ', \STR_PAD_LEFT);
+                $timeDiff = $timeDiff === ' 0.00' ? '<gray>    0</gray>' : $timeDiff;
 
                 $memoryDiff = FS::format($profile['memory_usage_diff'], 0);
                 $memoryDiff = \str_pad($memoryDiff, 6, ' ', \STR_PAD_LEFT);
-                if ($profile['memory_usage_diff'] === 0) {
-                    $memoryDiff = '<gray>' . \str_pad('0', 6, ' ', \STR_PAD_LEFT) . '</gray>';
+                if (\abs($profile['memory_usage_diff']) < 1024) {
+                    $memoryDiff = '<gray>' . \str_pad($memoryDiff, 6, ' ', \STR_PAD_LEFT) . '</gray>';
                 } else {
                     $memoryDiff = $profile['memory_usage_diff'] > 0
                         ? "<yellow>{$memoryDiff}</yellow>"
@@ -260,17 +260,17 @@ class Text extends AbstractOutputMode
                         $profilerData[] = $timeTotal;
                         $profilerData[] = $timeDiff;
                         $profilerData[] = $memoryDiff;
-                        $profilerData[] = FS::format($profile['memory_usage'], 0);
-                        $profilerData[] = 'P: ' . FS::format($profile['memory_peak'], 0);
+                        $profilerData[] = \str_pad(FS::format($profile['memory_usage'], 0), 7, ' ', \STR_PAD_LEFT);
+                        $profilerData[] = 'P:' . FS::format($profile['memory_peak'], 0);
                     } elseif ($this->showMessage(OutputInterface::VERBOSITY_VERY_VERBOSE)) {
                         $profilerData[] = $timeTotal;
                         $profilerData[] = $timeDiff;
                         $profilerData[] = $memoryDiff;
-                        $profilerData[] = FS::format($profile['memory_usage'], 0);
+                        $profilerData[] = \str_pad(FS::format($profile['memory_usage'], 0), 7, ' ', \STR_PAD_LEFT);
                     } elseif ($this->showMessage(OutputInterface::VERBOSITY_VERBOSE)) {
                         $profilerData[] = $timeDiff;
                         $profilerData[] = $memoryDiff;
-                        $profilerData[] = FS::format($profile['memory_usage'], 0);
+                        $profilerData[] = \str_pad(FS::format($profile['memory_usage'], 0), 7, ' ', \STR_PAD_LEFT);
                     } else {
                         $profilerData[] = $timeDiff;
                         $profilerData[] = $memoryDiff;
@@ -278,7 +278,7 @@ class Text extends AbstractOutputMode
                 }
 
                 $profilePrefix .= '<green>[</green>'
-                    . \implode(' <green>|</green> ', $profilerData)
+                    . \implode('<green>|</green>', $profilerData)
                     . '<green>]</green> ';
             }
             $printCallback($profilePrefix);

--- a/tests/CliOutputTextTest.php
+++ b/tests/CliOutputTextTest.php
@@ -157,7 +157,7 @@ class CliOutputTextTest extends PHPUnit
         isContain('; Real peak:', $cmdResult->std);
         isContain('; Time:', $cmdResult->std);
         isNotContain(' ms (bootstrap)', $cmdResult->std);
-        isContain('Info: Exit Code is "0"', $cmdResult->std);
+        isContain('Debug: Exit Code is "0"', $cmdResult->std);
     }
 
     public function testDebugAndProfiler(): void
@@ -187,7 +187,6 @@ class CliOutputTextTest extends PHPUnit
         isContain('Memory:', $cmdResult->std);
         isContain('Real peak:', $cmdResult->std);
         isContain('Time:', $cmdResult->std);
-        isContain('Exit Code is "0"', $cmdResult->std);
     }
 
     public function testStdoutOnly(): void

--- a/tests/CliOutputTextTest.php
+++ b/tests/CliOutputTextTest.php
@@ -181,9 +181,9 @@ class CliOutputTextTest extends PHPUnit
     {
         $cmdResult = Helper::executeReal('test:output', ['profile' => null]);
 
-        isContain('B] Normal 1', $cmdResult->std);
-        isContain('B] Normal 2', $cmdResult->std);
-        isContain('B] Quiet -q', $cmdResult->std);
+        isContain('] Normal 1', $cmdResult->std);
+        isContain('] Normal 2', $cmdResult->std);
+        isContain('] Quiet -q', $cmdResult->std);
         isContain('Memory:', $cmdResult->std);
         isContain('Real peak:', $cmdResult->std);
         isContain('Time:', $cmdResult->std);


### PR DESCRIPTION
Some minor adjustments were made to improve readability and accuracy of output. Padding was added to further standardize the spacing of output values, some conditionals were adjusted, and 'Exit Code' output was changed from 'Info' to 'Debug' level. Extraneous test assertions were removed accordingly.