### PR TITLE
Add PHP 8.4 compatibility and improve testing configurations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
         run: make report-coveralls --no-print-directory || true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: PHPUnit - ${{ matrix.php-version }} - ${{ matrix.coverage }}
@@ -99,7 +99,7 @@ jobs:
         run: make codestyle --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Linters - ${{ matrix.php-version }}
@@ -133,7 +133,7 @@ jobs:
         run: make report-all --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Reports - ${{ matrix.php-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.1, 8.2, 8.3, 8.4 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.1, 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.1, 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/composer.json
+++ b/composer.json
@@ -34,16 +34,16 @@
     "prefer-stable"     : true,
 
     "require"           : {
-        "php"                                 : "^8.1",
+        "php"                               : "^8.1",
 
-        "jbzoo/utils"                         : "^7.1",
-        "jbzoo/event"                         : "^7.0",
+        "jbzoo/utils"                       : "^7.1",
+        "jbzoo/event"                       : "^7.0",
 
-        "symfony/process"                     : ">=6.4",
-        "symfony/console"                     : ">=6.4",
-        "symfony/lock"                        : ">=6.4",
-        "bluepsyduck/symfony-process-manager" : ">=1.3.3",
-        "monolog/monolog"                     : "^3.4"
+        "symfony/process"                   : ">=6.4",
+        "symfony/console"                   : ">=6.4",
+        "symfony/lock"                      : ">=6.4",
+        "smetdenis/symfony-process-manager" : ">=1.3.3",
+        "monolog/monolog"                   : "^3.4"
     },
 
     "require-dev"       : {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 #
-# JBZoo Toolbox - Cli.
+# JBZoo Toolbox - Codestyle.
 #
 # This file is part of the JBZoo Toolbox project.
 # For the full copyright and license information, please view the LICENSE
@@ -7,7 +7,7 @@
 #
 # @license    MIT
 # @copyright  Copyright (C) JBZoo.com, All rights reserved.
-# @see        https://github.com/JBZoo/Cli
+# @see        https://github.com/JBZoo/Codestyle
 #
 
 includes:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,19 @@
+#
+# JBZoo Toolbox - Cli.
+#
+# This file is part of the JBZoo Toolbox project.
+# For the full copyright and license information, please view the LICENSE
+# file that was distributed with this source code.
+#
+# @license    MIT
+# @copyright  Copyright (C) JBZoo.com, All rights reserved.
+# @see        https://github.com/JBZoo/Cli
+#
+
+includes:
+    - ./vendor/phpstan/phpstan-strict-rules/rules.neon
+
+parameters:
+    level: max
+    checkExplicitMixed: false
+    reportUnmatchedIgnoredErrors: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 #
-# JBZoo Toolbox - Codestyle.
+# JBZoo Toolbox - Cli.
 #
 # This file is part of the JBZoo Toolbox project.
 # For the full copyright and license information, please view the LICENSE
@@ -7,7 +7,7 @@
 #
 # @license    MIT
 # @copyright  Copyright (C) JBZoo.com, All rights reserved.
-# @see        https://github.com/JBZoo/Codestyle
+# @see        https://github.com/JBZoo/Cli
 #
 
 includes:

--- a/tests/CliPackageTest.php
+++ b/tests/CliPackageTest.php
@@ -26,4 +26,9 @@ final class CliPackageTest extends \JBZoo\Codestyle\PHPUnit\AbstractPackageTest
 
         $this->excludePaths[] = '.github/assets';
     }
+
+    protected static function phpVersions(): array
+    {
+        return [8.1, 8.2, 8.3, 8.4];
+    }
 }

--- a/tests/CliPackageTest.php
+++ b/tests/CliPackageTest.php
@@ -31,4 +31,14 @@ final class CliPackageTest extends \JBZoo\Codestyle\PHPUnit\AbstractPackageTest
     {
         return [8.1, 8.2, 8.3, 8.4];
     }
+
+    protected static function uploadArtifactsStep(string $stepName): array
+    {
+        return [
+            'name'              => 'Upload Artifacts',
+            'uses'              => 'actions/upload-artifact@v4',
+            'continue-on-error' => true,
+            'with'              => ['name' => $stepName, 'path' => 'build/'],
+        ];
+    }
 }


### PR DESCRIPTION
Update GitHub Actions workflow to include PHP 8.4 in the testing matrix. Modify the test file to define supported PHP versions in a centralized method, ensuring consistency. Additionally, create a phpstan.neon file for improved static analysis with strict rules.

These changes enhance the project's compatibility with the latest PHP version, ensure better test coverage, and facilitate improved code quality through static analysis.