### PR TITLE
refactor(cli): Make CliApplication extendable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # JBZoo / Cli
 
-[![CI](https://github.com/JBZoo/Cli/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Cli/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Cli/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Cli?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Cli/coverage.svg)](https://shepherd.dev/github/JBZoo/Cli)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Cli/level.svg)](https://shepherd.dev/github/JBZoo/Cli)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/cli/badge)](https://www.codefactor.io/repository/github/jbzoo/cli/issues)
-[![Stable Version](https://poser.pugx.org/jbzoo/cli/version)](https://packagist.org/packages/jbzoo/cli/)    [![Total Downloads](https://poser.pugx.org/jbzoo/cli/downloads)](https://packagist.org/packages/jbzoo/cli/stats)    [![Dependents](https://poser.pugx.org/jbzoo/cli/dependents)](https://packagist.org/packages/jbzoo/cli/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/cli)](https://github.com/JBZoo/Cli/blob/master/LICENSE)
+[![CI](https://github.com/JBZoo/Cli/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Cli/actions/workflows/main.yml?query=branch%3Amaster)
+[![Coverage Status](https://coveralls.io/repos/github/JBZoo/Cli/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Cli?branch=master)
+[![Psalm Coverage](https://shepherd.dev/github/JBZoo/Cli/coverage.svg)](https://shepherd.dev/github/JBZoo/Cli)
+[![Psalm Level](https://shepherd.dev/github/JBZoo/Cli/level.svg)](https://shepherd.dev/github/JBZoo/Cli)
+[![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/cli/badge)](https://www.codefactor.io/repository/github/jbzoo/cli/issues)
+
+[![Stable Version](https://poser.pugx.org/jbzoo/cli/version)](https://packagist.org/packages/jbzoo/cli/)
+[![Total Downloads](https://poser.pugx.org/jbzoo/cli/downloads)](https://packagist.org/packages/jbzoo/cli/stats)
+[![Dependents](https://poser.pugx.org/jbzoo/cli/dependents)](https://packagist.org/packages/jbzoo/cli/dependents?order_by=downloads)
+[![GitHub License](https://img.shields.io/github/license/jbzoo/cli)](https://github.com/JBZoo/Cli/blob/master/LICENSE)
 
 
 <!--ts-->

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     },
 
     "require-dev" :       {
-        "jbzoo/toolbox-dev" : "^7.2"
+        "jbzoo/toolbox-dev" : "^7.3"
     },
 
     "autoload" :          {

--- a/src/CliApplication.php
+++ b/src/CliApplication.php
@@ -102,7 +102,6 @@ class CliApplication extends Application
 
     /**
      * @SuppressWarnings(ShortVariable)
-     * @psalm-suppress ParamNameMismatch
      */
     public function renderThrowable(\Throwable $e, OutputInterface $output): void
     {

--- a/src/CliApplication.php
+++ b/src/CliApplication.php
@@ -25,7 +25,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 use function JBZoo\Utils\isStrEmpty;
 
-final class CliApplication extends Application
+/**
+ * @psalm-suppress ClassMustBeFinal
+ */
+class CliApplication extends Application
 {
     private ?EventManager       $eventManager = null;
     private ?string             $logo         = null;
@@ -99,6 +102,7 @@ final class CliApplication extends Application
 
     /**
      * @SuppressWarnings(ShortVariable)
+     * @psalm-suppress ParamNameMismatch
      */
     public function renderThrowable(\Throwable $e, OutputInterface $output): void
     {

--- a/src/CliCommand.php
+++ b/src/CliCommand.php
@@ -44,7 +44,6 @@ abstract class CliCommand extends Command
     abstract protected function executeAction(): int;
 
     /**
-     * @psalm-suppress PossiblyUnusedReturnValue
      * @param int|iterable<mixed> $listOrMax
      */
     public function progressBar(
@@ -339,9 +338,6 @@ abstract class CliCommand extends Command
         return $this->outputMode->isDisplayProfiling();
     }
 
-    /**
-     * @psalm-suppress PossiblyUnusedReturnValue
-     */
     protected function trigger(string $eventName, array $arguments = [], ?callable $continueCallback = null): int
     {
         $application = $this->getApplication();

--- a/src/ProcessManager/ProcessManagerInterface.php
+++ b/src/ProcessManager/ProcessManagerInterface.php
@@ -28,13 +28,11 @@ interface ProcessManagerInterface
 {
     /**
      * Adds a process to the manager.
-     * @psalm-suppress PossiblyUnusedReturnValue
      */
     public function addProcess(Process $process, ?callable $callback = null, array $env = []): self;
 
     /**
      * Waits for all processes to be finished.
-     * @psalm-suppress PossiblyUnusedReturnValue
      */
     public function waitForAllProcesses(): self;
 

--- a/src/ProgressBars/AbstractProgressBar.php
+++ b/src/ProgressBars/AbstractProgressBar.php
@@ -34,9 +34,6 @@ abstract class AbstractProgressBar
     protected ?\Closure $callbackOnStart  = null;
     protected ?\Closure $callbackOnFinish = null;
 
-    /**
-     * @psalm-suppress PossiblyUnusedReturnValue
-     */
     abstract public function execute(): bool;
 
     public function __construct(AbstractOutputMode $outputMode)


### PR DESCRIPTION
- Remove `final` keyword from `CliApplication` to allow inheritance.
- Add `@psalm-suppress` annotations to address static analysis warnings.